### PR TITLE
環境変数を1箇所に集約する

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+CMS_API_KEY="xxxxx"
+NEXT_PUBLIC_VERCEL_URL="http://localhost:3000"

--- a/app/_config/index.ts
+++ b/app/_config/index.ts
@@ -1,0 +1,2 @@
+export const API_KEY = process.env.CMS_API_KEY as string;
+export const SITE_URL = process.env.NEXT_PUBLIC_VERCEL_URL || '';

--- a/app/_lib/blog-client.ts
+++ b/app/_lib/blog-client.ts
@@ -1,6 +1,5 @@
 import { createClient } from 'microcms-js-sdk';
-
-const apiKey = process.env.CMS_API_KEY as string;
+import { API_KEY } from '../_config';
 
 interface Image {
   url: string;
@@ -22,5 +21,5 @@ export interface Post {
 
 export const blogClient = createClient({
   serviceDomain: 'hakshu-blog',
-  apiKey: apiKey,
+  apiKey: API_KEY,
 });

--- a/app/_lib/site-info.ts
+++ b/app/_lib/site-info.ts
@@ -1,2 +1,1 @@
 export const siteTitle = "Hakshu's Blog";
-export const siteUrl: string = process.env.NEXT_PUBLIC_VERCEL_URL || '';

--- a/app/rss/route.ts
+++ b/app/rss/route.ts
@@ -1,10 +1,10 @@
+import { SITE_URL } from '../_config';
 import { blogClient } from '../_lib/blog-client';
 import { generateRssXml } from '../_lib/rss';
-import { siteUrl } from '../_lib/site-info';
 
 export async function GET() {
   const { contents } = await blogClient.get({ endpoint: 'posts' });
-  const xml = generateRssXml(contents, siteUrl);
+  const xml = generateRssXml(contents, SITE_URL);
   return new Response(xml, {
     status: 200,
     headers: {


### PR DESCRIPTION
## 変更理由
- 扱っている環境変数は少ないが、複数箇所で同じ環境変数を使っていると変更が生じた場合に手間がかかるため

## 参考にしたもの
- ディレクトリ構成を参考にした
  - https://github.com/alan2207/bulletproof-react/blob/11d9149c9bb2af0def640d3b690b52db36028428/docs/project-structure.md

## やったこと
- 環境変数参照を `app/_config/index.ts` に集約し、今まで直接使っていたところはここからimportするよう変更
- ローカル環境用の環境変数サンプルファイルを追加