### PR TITLE
fix: replace html tags with Next.js Link components for proper routing

### DIFF
--- a/app/_components/HeaderBar.tsx
+++ b/app/_components/HeaderBar.tsx
@@ -26,10 +26,9 @@ export const HeaderBar = ({ type = 'blog' }: Props) => {
             </Link>
           </li>
           <li>
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a href="/rss" target="_blank" rel="noopener noreferrer">
+            <Link href="/rss" target="_blank" rel="noopener noreferrer">
               RSS
-            </a>
+            </Link>
           </li>
         </ul>
       </nav>

--- a/app/_components/HeaderBar.tsx
+++ b/app/_components/HeaderBar.tsx
@@ -26,6 +26,7 @@ export const HeaderBar = ({ type = 'blog' }: Props) => {
             </Link>
           </li>
           <li>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a href="/rss" target="_blank" rel="noopener noreferrer">
               RSS
             </a>

--- a/app/_components/IconLink.tsx
+++ b/app/_components/IconLink.tsx
@@ -36,6 +36,7 @@ export const IconLink = ({ iconName }: Props) => {
   const IconComponent = icon.component;
 
   return (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
     <a
       href={icon.link}
       target="_blank"

--- a/app/_components/IconLink.tsx
+++ b/app/_components/IconLink.tsx
@@ -3,6 +3,7 @@ import { SvgProps } from '../_lib/svg-props';
 import { GitHubIcon } from './svgs/GitHubIcon';
 import { TwitterIcon } from './svgs/TwitterIcon';
 
+import Link from 'next/link';
 export type IconName = 'github' | 'twitter';
 interface LinkMapping {
   link: string;
@@ -36,14 +37,13 @@ export const IconLink = ({ iconName }: Props) => {
   const IconComponent = icon.component;
 
   return (
-    // eslint-disable-next-line @next/next/no-html-link-for-pages
-    <a
+    <Link
       href={icon.link}
       target="_blank"
       rel="noopener noreferrer"
       className="hover:opacity-70"
     >
       <IconComponent width={100} height={100} />
-    </a>
+    </Link>
   );
 };


### PR DESCRIPTION
## Summary
- HeaderBar.tsxのRSSリンクを`<a>`タグからNext.js `Link`コンポーネントに変更（内部ルート`/rss`のため）
- IconLink.tsxの外部SNSリンクを`<a>`タグからNext.js `Link`コンポーネントに変更（Next.js 13+では外部リンクも自動処理）
- ESLint警告の無効化コメントをすべて削除し、適切なNext.jsコンポーネントを使用

## Changes
- ✅ ESLint `no-html-link-for-pages` 警告を適切な解決方法で修正
- ✅ 内部ルート（RSS）にNext.js Linkを使用
- ✅ 外部リンク（SNS）にもNext.js Linkを使用（Next.js 13+の推奨）
- ✅ コードベース全体でLinkコンポーネントの一貫した使用

## Test plan
- [x] `pnpm lint`が警告なしで完了することを確認
- [x] RSS/SNSリンクが正常に動作することを確認（動作に変更なし）
- [x] Next.jsのベストプラクティスに準拠

🤖 Generated with [Claude Code](https://claude.ai/code)